### PR TITLE
Поправка поведения при отсутствии контента

### DIFF
--- a/modules/menu/models/Menu.php
+++ b/modules/menu/models/Menu.php
@@ -245,7 +245,7 @@ class Menu extends DaActiveRecord implements ISearchable {
       return $this->uri;
     }
     
-    if ($this->go_to_type == Menu::GO_TO_FILE) {
+    if ($this->go_to_type == Menu::GO_TO_FILE && $this->content == null) {
       // Если в типе раздела указано, что нужно возвращать файл, то формируем ссылку на файл:
       // Если у раздела есть контент, то возвращаем ссылку на раздел, не смотря на то, что указан файл.
       $file = $this->firstFile;


### PR DESCRIPTION
Теперь если в меню выбрано показывать первый загруженный файл, то опция будет срабатывать только при отсутствии контента.
